### PR TITLE
Add main file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 
 # config
 .env
+/src/config

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Opinionated Typescript template for building Discord.js applications",
   "license": "MIT",
   "scripts": {
+    "start": "yarn build && yarn build:watch",
+    "build": "tsc",
+    "build:watch": "yarn tsc-watch --onSuccess 'nodemon dist/App.js'",
     "auto:changelog": "yarn auto changelog",
     "auto:version": "yarn version --`auto version`",
     "auto:release": "yarn auto:changelog && yarn auto:version",

--- a/src/App.ts
+++ b/src/App.ts
@@ -1,0 +1,15 @@
+import { Client, GatewayIntentBits } from 'discord.js';
+
+const app: Client = new Client({
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
+});
+
+const initialize = async (): Promise<void> => {
+  try {
+    await app.login();
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+initialize();

--- a/src/App.ts
+++ b/src/App.ts
@@ -1,4 +1,5 @@
 import { Client, GatewayIntentBits } from 'discord.js';
+import { BOT_TOKEN } from './config/environment';
 
 const app: Client = new Client({
   intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
@@ -6,7 +7,7 @@ const app: Client = new Client({
 
 const initialize = async (): Promise<void> => {
   try {
-    await app.login();
+    await app.login(BOT_TOKEN);
   } catch (error) {
     console.log(error);
   }

--- a/src/App.ts
+++ b/src/App.ts
@@ -9,7 +9,7 @@ const initialize = async (): Promise<void> => {
   try {
     await app.login(BOT_TOKEN);
   } catch (error) {
-    console.log(error);
+    throw error;
   }
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noImplicitAny": true,
+    "allowJs": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
#### Context
Adds the main file which will be the entry point of the app. Pretty much this is where all the initialisation of the client and third-party dependencies will be stored

#### Change
- Create tsconfig
- Create main file
- Add scripts for building

#### Considerations
I've ignored the config folder for now but since this would be a template, it's probably better to push a boilerplate of that and add instructions on removing it
