### PR TITLE
Add events structure

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1,13 +1,15 @@
 import { Client, GatewayIntentBits } from 'discord.js';
 import { BOT_TOKEN } from './config/environment';
+import { registerEventHandlers } from './events/events';
 
 const app: Client = new Client({
-  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
+  intents: [GatewayIntentBits.Guilds],
 });
 
 const initialize = async (): Promise<void> => {
   try {
     await app.login(BOT_TOKEN);
+    registerEventHandlers({ app });
   } catch (error) {
     throw error;
   }

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,0 +1,36 @@
+import { Client } from 'discord.js';
+import fs from 'fs';
+import path from 'path';
+
+interface Props {
+  app: Client;
+}
+type ExportedEventModule = {
+  default: (data: EventModule) => void;
+};
+export type EventModule = {
+  app: Client;
+};
+export function registerEventHandlers({ app }: Props): void {
+  const loadModules = (directoryPath: string) => {
+    fs.readdir(directoryPath, { withFileTypes: true }, (error, files) => {
+      if (error) {
+        //TODO: Replace with error handling
+        console.log(error);
+      }
+      files &&
+        files.forEach((file) => {
+          const filePath = path.join(directoryPath, file.name);
+          if (file.isDirectory()) {
+            return loadModules(filePath);
+          }
+          if (file.name === 'index.js') {
+            const modulePath = `.${filePath.replace('dist/events', '')}`;
+            const currentModule = require(modulePath) as ExportedEventModule;
+            currentModule.default({ app });
+          }
+        });
+    });
+  };
+  loadModules('./dist/events');
+}

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -1,0 +1,14 @@
+import { Client } from 'discord.js';
+
+interface Props {
+  app: Client;
+}
+export default function ({ app }: Props) {
+  app.once('ready', async () => {
+    try {
+      console.log("I'm booting up! (◕ᴗ◕✿)");
+    } catch (error) {
+      console.log(error);
+    }
+  });
+}


### PR DESCRIPTION
#### Context
Adds the structure of event files and automatically exporting its modules. Only added the ready event for now since I don't need the others for now

<img width="361" alt="image" src="https://user-images.githubusercontent.com/42207245/230590612-9ea05dbf-58fc-4542-bc83-7e24bc0a3e60.png">

#### Change
- Create events file
- Create ready event
