### PR TITLE
Add interaction create event

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -8,7 +8,7 @@ export type AppCommands = {
 };
 export type AppCommand = {
   data: SlashCommandBuilder;
-  execute: (data: AppCommandOptions) => void;
+  execute: (data: AppCommandOptions) => Promise<void>;
 };
 export type AppCommandOptions = {
   interaction: CommandInteraction;

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,0 +1,15 @@
+import { CacheType, Interaction } from 'discord.js';
+import { AppCommands } from '../../commands/commands';
+import { EventModule } from '../events';
+
+export default function ({ app, appCommands }: EventModule) {
+  app.on('interactionCreate', async (interaction: Interaction<CacheType>) => {
+    if (!interaction.inGuild() || !appCommands) return;
+
+    if (interaction.isCommand()) {
+      const { commandName } = interaction;
+      const command = appCommands[commandName as keyof AppCommands];
+      command && (await command.execute({ interaction, app }));
+    }
+  });
+}

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -4,13 +4,18 @@ import { EventModule } from '../events';
 
 export default function ({ app, appCommands }: EventModule) {
   app.on('interactionCreate', async (interaction: Interaction<CacheType>) => {
-    if (!interaction.inGuild() || !appCommands) return;
+    try {
+      if (!interaction.inGuild() || !appCommands) return;
 
-    if (interaction.isCommand()) {
-      const { commandName } = interaction;
-      const command = appCommands[commandName as keyof AppCommands];
-      command && (await command.execute({ interaction, app }));
+      if (interaction.isCommand()) {
+        const { commandName } = interaction;
+        const command = appCommands[commandName as keyof AppCommands];
+        command && (await command.execute({ interaction, app }));
+      }
+      //Maybe add buttons, selections and modal handlers here eventually
+    } catch (errors) {
+      //TODO: Add error handling
+      console.log(errors);
     }
-    //Maybe add buttons, selections and modal handlers here eventually
   });
 }

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -11,5 +11,6 @@ export default function ({ app, appCommands }: EventModule) {
       const command = appCommands[commandName as keyof AppCommands];
       command && (await command.execute({ interaction, app }));
     }
+    //Maybe add buttons, selections and modal handlers here eventually
   });
 }


### PR DESCRIPTION
#### Context
This creates the interactionCreate event handler which will listen for whenever interactions get received by the bot. Only added the default command interaction for now, don't really see any reason in adding the rest i.e. buttons, selections, modals etc since that seems like they are only on a per use basis. Maybe in the future tho

<img width="307" alt="image" src="https://user-images.githubusercontent.com/42207245/230710760-25273a1a-cb8f-4907-b549-4e747e689640.png">

#### Change
- Create interaction create event
