### PR TITLE
Add guild notifications

### DIFF
--- a/src/events/guildCreate/index.ts
+++ b/src/events/guildCreate/index.ts
@@ -1,0 +1,27 @@
+import { Guild, WebhookClient } from 'discord.js';
+import { isEmpty } from 'lodash';
+import { GUILD_NOTIFICATION_WEBHOOK_URL, USE_DATABASE } from '../../config/environment';
+import { insertNewGuild } from '../../services/database';
+import { serverNotificationEmbed } from '../../utils/helpers';
+import { EventModule } from '../events';
+
+export default function ({ app }: EventModule) {
+  app.on('guildCreate', async (guild: Guild) => {
+    try {
+      USE_DATABASE && (await insertNewGuild(guild));
+      if (GUILD_NOTIFICATION_WEBHOOK_URL && !isEmpty(GUILD_NOTIFICATION_WEBHOOK_URL)) {
+        const embed = await serverNotificationEmbed({ app, guild, type: 'join' });
+        const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });
+        await notificationWebhook.send({
+          embeds: [embed],
+          username: 'Yagi Server Notificaiton',
+          avatarURL:
+            'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png',
+        });
+      }
+    } catch (error) {
+      //TODO: Add error handling
+      console.log(error);
+    }
+  });
+}

--- a/src/events/guildDelete/index.ts
+++ b/src/events/guildDelete/index.ts
@@ -1,16 +1,16 @@
 import { Guild, WebhookClient } from 'discord.js';
 import { isEmpty } from 'lodash';
 import { GUILD_NOTIFICATION_WEBHOOK_URL, USE_DATABASE } from '../../config/environment';
-import { insertNewGuild } from '../../services/database';
+import { deleteGuild } from '../../services/database';
 import { serverNotificationEmbed } from '../../utils/helpers';
 import { EventModule } from '../events';
 
 export default function ({ app }: EventModule) {
-  app.on('guildCreate', async (guild: Guild) => {
+  app.on('guildDelete', async (guild: Guild) => {
     try {
-      USE_DATABASE && (await insertNewGuild(guild));
+      USE_DATABASE && (await deleteGuild(guild));
       if (GUILD_NOTIFICATION_WEBHOOK_URL && !isEmpty(GUILD_NOTIFICATION_WEBHOOK_URL)) {
-        const embed = await serverNotificationEmbed({ app, guild, type: 'join' });
+        const embed = await serverNotificationEmbed({ app, guild, type: 'leave' });
         const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });
         await notificationWebhook.send({
           embeds: [embed],

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,51 +1,46 @@
-import { Client, Guild } from 'discord.js';
+import { APIEmbed, Client, Guild } from 'discord.js';
 
 export const serverNotificationEmbed = async ({
   app,
   guild,
-  status,
+  type,
 }: {
   app: Client;
   guild: Guild;
-  status: 'join' | 'leave';
-}) => {
-  try {
-    const defaultIcon =
-      'https://cdn.discordapp.com/attachments/248430185463021569/614789995596742656/Wallpaper2.png';
-    const guildIcon = guild.icon && guild.iconURL();
-    const guildOwner =
-      status === 'join'
-        ? await guild.members.fetch(guild.ownerId).then((guildMember) => guildMember.user.tag)
-        : '-';
+  type: 'join' | 'leave';
+}): Promise<APIEmbed> => {
+  const defaultIcon =
+    'https://cdn.discordapp.com/attachments/248430185463021569/614789995596742656/Wallpaper2.png';
+  const guildIcon = guild.icon && guild.iconURL();
+  const guildOwner =
+    type === 'join'
+      ? await guild.members.fetch(guild.ownerId).then((guildMember) => guildMember.user.tag)
+      : '-';
 
-    const embed = {
-      title: status === 'join' ? 'Joined a new server' : 'Left a server',
-      description: `I'm now in **${app.guilds.cache.size}** servers!`,
-      color: status === 'join' ? 55296 : 16711680,
-      thumbnail: {
-        url: guildIcon ? guildIcon.replace(/jpeg|jpg/gi, 'png') : defaultIcon,
+  const embed = {
+    title: type === 'join' ? 'Joined a new server' : 'Left a server',
+    description: `I'm now in **${app.guilds.cache.size}** servers!`,
+    color: type === 'join' ? 55296 : 16711680,
+    thumbnail: {
+      url: guildIcon ? guildIcon.replace(/jpeg|jpg/gi, 'png') : defaultIcon,
+    },
+    fields: [
+      {
+        name: 'Name',
+        value: guild.name,
+        inline: true,
       },
-      fields: [
-        {
-          name: 'Name',
-          value: guild.name,
-          inline: true,
-        },
-        {
-          name: 'Owner',
-          value: guildOwner,
-          inline: true,
-        },
-        {
-          name: 'Members',
-          value: guild.memberCount.toString(),
-          inline: true,
-        },
-      ],
-    };
-    return embed;
-  } catch (error) {
-    //TODO: Add error handling
-    console.log(error);
-  }
+      {
+        name: 'Owner',
+        value: guildOwner,
+        inline: true,
+      },
+      {
+        name: 'Members',
+        value: guild.memberCount.toString(),
+        inline: true,
+      },
+    ],
+  };
+  return embed;
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,51 @@
+import { Client, Guild } from 'discord.js';
+
+export const serverNotificationEmbed = async ({
+  app,
+  guild,
+  status,
+}: {
+  app: Client;
+  guild: Guild;
+  status: 'join' | 'leave';
+}) => {
+  try {
+    const defaultIcon =
+      'https://cdn.discordapp.com/attachments/248430185463021569/614789995596742656/Wallpaper2.png';
+    const guildIcon = guild.icon && guild.iconURL();
+    const guildOwner =
+      status === 'join'
+        ? await guild.members.fetch(guild.ownerId).then((guildMember) => guildMember.user.tag)
+        : '-';
+
+    const embed = {
+      title: status === 'join' ? 'Joined a new server' : 'Left a server',
+      description: `I'm now in **${app.guilds.cache.size}** servers!`,
+      color: status === 'join' ? 55296 : 16711680,
+      thumbnail: {
+        url: guildIcon ? guildIcon.replace(/jpeg|jpg/gi, 'png') : defaultIcon,
+      },
+      fields: [
+        {
+          name: 'Name',
+          value: guild.name,
+          inline: true,
+        },
+        {
+          name: 'Owner',
+          value: guildOwner,
+          inline: true,
+        },
+        {
+          name: 'Members',
+          value: guild.memberCount.toString(),
+          inline: true,
+        },
+      ],
+    };
+    return embed;
+  } catch (error) {
+    //TODO: Add error handling
+    console.log(error);
+  }
+};


### PR DESCRIPTION
#### Context
Adds handling for when the bot joins or leaves a server. This will insert or delete the guild in the database if the config is using a database as well as sending a notification to a webhook in a discord channel

<img width="463" alt="image" src="https://user-images.githubusercontent.com/42207245/230723254-a9e9f8df-136a-45bc-9ab6-92ce4355dbee.png">

#### Change
- Create server norifications helper
- Create guildCreate event
- Create guildDelete event

#### Considerations
Might be good to make a guild notification helper since I am kinda repeating myself in these events. Might even better to even publish it as a package. I think it's fine keeping it as it is tho. 
