### PR TITLE
Add error logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lodash": "^4.17.21",
     "mixpanel": "^0.17.0",
     "pg": "^8.10.0",
-    "topgg-autoposter": "^2.0.1"
+    "topgg-autoposter": "^2.0.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/jest": "^29.5.0",
     "@types/lodash": "^4.14.191",
     "@types/pg": "^8.6.6",
+    "@types/uuid": "^9.0.1",
     "auto": "^10.43.0",
     "eslint": "^8.36.0",
     "eslint-plugin-unused-imports": "^2.0.0",

--- a/src/App.ts
+++ b/src/App.ts
@@ -1,6 +1,7 @@
 import { Client, GatewayIntentBits } from 'discord.js';
 import { BOT_TOKEN } from './config/environment';
 import { registerEventHandlers } from './events/events';
+import { sendErrorLog } from './utils/helpers';
 
 const app: Client = new Client({
   intents: [GatewayIntentBits.Guilds],
@@ -11,7 +12,7 @@ const initialize = async (): Promise<void> => {
     await app.login(BOT_TOKEN);
     registerEventHandlers({ app });
   } catch (error) {
-    throw error;
+    sendErrorLog({ error });
   }
 };
 

--- a/src/commands/hello/index.ts
+++ b/src/commands/hello/index.ts
@@ -6,10 +6,11 @@ export default {
   data: new SlashCommandBuilder().setName('hello').setDescription('Greets the user!'),
   async execute({ interaction }: AppCommandOptions) {
     try {
-      throw new Error('This is a test');
       await interaction.deferReply();
       await interaction.editReply('Hello!');
+      throw new Error('This is a test');
     } catch (error) {
+      console.log(interaction.commandName);
       sendErrorLog(error);
     }
   },

--- a/src/commands/hello/index.ts
+++ b/src/commands/hello/index.ts
@@ -7,8 +7,8 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
-      await interaction.editReply('Hello!');
       throw new Error('This is a test');
+      await interaction.editReply('Hello!');
     } catch (error) {
       sendErrorLog({ error, interaction });
     }

--- a/src/commands/hello/index.ts
+++ b/src/commands/hello/index.ts
@@ -7,7 +7,6 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
-      throw new Error('This is a test');
       await interaction.editReply('Hello!');
     } catch (error) {
       sendErrorLog({ error, interaction });

--- a/src/commands/hello/index.ts
+++ b/src/commands/hello/index.ts
@@ -1,14 +1,16 @@
 import { SlashCommandBuilder } from 'discord.js';
+import { sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
 export default {
   data: new SlashCommandBuilder().setName('hello').setDescription('Greets the user!'),
   async execute({ interaction }: AppCommandOptions) {
     try {
+      throw new Error('This is a test');
       await interaction.deferReply();
       await interaction.editReply('Hello!');
     } catch (error) {
-      console.log(error);
+      sendErrorLog(error);
     }
   },
 } as AppCommand;

--- a/src/commands/hello/index.ts
+++ b/src/commands/hello/index.ts
@@ -10,8 +10,7 @@ export default {
       await interaction.editReply('Hello!');
       throw new Error('This is a test');
     } catch (error) {
-      console.log(interaction.commandName);
-      sendErrorLog(error);
+      sendErrorLog({ error, interaction });
     }
   },
 } as AppCommand;

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -2,6 +2,7 @@ import { Client } from 'discord.js';
 import fs from 'fs';
 import path from 'path';
 import { AppCommands, getApplicationCommands } from '../commands/commands';
+import { sendErrorLog } from '../utils/helpers';
 
 const appCommands = getApplicationCommands();
 
@@ -19,8 +20,7 @@ export function registerEventHandlers({ app }: Props): void {
   const loadModules = (directoryPath: string) => {
     fs.readdir(directoryPath, { withFileTypes: true }, (error, files) => {
       if (error) {
-        //TODO: Replace with error handling
-        console.log(error);
+        sendErrorLog({ error });
       }
       files &&
         files.forEach((file) => {

--- a/src/events/guildCreate/index.ts
+++ b/src/events/guildCreate/index.ts
@@ -2,7 +2,7 @@ import { Guild, WebhookClient } from 'discord.js';
 import { isEmpty } from 'lodash';
 import { GUILD_NOTIFICATION_WEBHOOK_URL, USE_DATABASE } from '../../config/environment';
 import { insertNewGuild } from '../../services/database';
-import { serverNotificationEmbed } from '../../utils/helpers';
+import { sendErrorLog, serverNotificationEmbed } from '../../utils/helpers';
 import { EventModule } from '../events';
 
 export default function ({ app }: EventModule) {
@@ -19,8 +19,7 @@ export default function ({ app }: EventModule) {
         });
       }
     } catch (error) {
-      //TODO: Add error handling
-      console.log(error);
+      sendErrorLog({ error });
     }
   });
 }

--- a/src/events/guildDelete/index.ts
+++ b/src/events/guildDelete/index.ts
@@ -2,7 +2,7 @@ import { Guild, WebhookClient } from 'discord.js';
 import { isEmpty } from 'lodash';
 import { GUILD_NOTIFICATION_WEBHOOK_URL, USE_DATABASE } from '../../config/environment';
 import { deleteGuild } from '../../services/database';
-import { serverNotificationEmbed } from '../../utils/helpers';
+import { sendErrorLog, serverNotificationEmbed } from '../../utils/helpers';
 import { EventModule } from '../events';
 
 export default function ({ app }: EventModule) {
@@ -19,8 +19,7 @@ export default function ({ app }: EventModule) {
         });
       }
     } catch (error) {
-      //TODO: Add error handling
-      console.log(error);
+      sendErrorLog({ error });
     }
   });
 }

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,5 +1,6 @@
 import { CacheType, Interaction } from 'discord.js';
 import { AppCommands } from '../../commands/commands';
+import { sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
 
 export default function ({ app, appCommands }: EventModule) {
@@ -13,9 +14,8 @@ export default function ({ app, appCommands }: EventModule) {
         command && (await command.execute({ interaction, app }));
       }
       //Maybe add buttons, selections and modal handlers here eventually
-    } catch (errors) {
-      //TODO: Add error handling
-      console.log(errors);
+    } catch (error) {
+      sendErrorLog({ error });
     }
   });
 }

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -2,6 +2,7 @@ import { REST, Routes } from 'discord.js';
 import { AppCommands } from '../../commands/commands';
 import { BOT_TOKEN, ENV, GUILD_IDS, USE_DATABASE } from '../../config/environment';
 import { createGuildTable, populateGuilds } from '../../services/database';
+import { sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
 
 const rest = new REST({ version: '9' }).setToken(BOT_TOKEN);
@@ -32,8 +33,7 @@ const registerApplicationCommands = async (commands?: AppCommands) => {
       console.log('Successfully registered global application commands');
     }
   } catch (error) {
-    //TODO: Add error handling
-    console.log(error);
+    sendErrorLog({ error });
   }
 };
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,6 +1,7 @@
 import { Collection, Guild } from 'discord.js';
 import { Pool, PoolClient } from 'pg';
 import { databaseConfig } from '../config/database';
+import { sendErrorLog } from '../utils/helpers';
 const pool: Pool = new Pool(databaseConfig);
 
 type GuildRecord = {
@@ -21,8 +22,7 @@ export async function createGuildTable() {
       await client.query('COMMIT');
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error);
-      //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -38,8 +38,7 @@ export async function getGuilds() {
       return allGuilds;
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error);
-      //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -57,8 +56,7 @@ export async function populateGuilds(existingGuilds: Collection<string, Guild>) 
       }
     });
   } catch (error) {
-    console.log(error);
-    //TODO: Add error handling
+    sendErrorLog({ error });
   }
 }
 export async function insertNewGuild(newGuild: Guild) {
@@ -77,8 +75,7 @@ export async function insertNewGuild(newGuild: Guild) {
       await client.query('COMMIT');
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error);
-      //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -94,7 +91,7 @@ export async function deleteGuild(existingGuild: Guild) {
       await client.query('COMMIT');
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error);
+      sendErrorLog({ error });
     } finally {
       client.release();
     }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,11 @@
-import { APIEmbed, Client, CommandInteraction, Guild, WebhookClient } from 'discord.js';
+import {
+  APIEmbed,
+  Client,
+  CommandInteraction,
+  Guild,
+  GuildChannel,
+  WebhookClient,
+} from 'discord.js';
 import { capitalize, isEmpty } from 'lodash';
 import { ERROR_NOTIFICATION_WEBHOOK_URL } from '../config/environment';
 import { v4 as uuid } from 'uuid';
@@ -55,12 +62,46 @@ export const sendErrorLog = async ({
   error: any;
   interaction?: CommandInteraction;
 }) => {
-  console.log(error);
   if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
-    const embed = {
+    const interactionChannel = interaction?.channel as GuildChannel | undefined;
+    const embed: APIEmbed = {
       title: interaction ? `Error | ${capitalize(interaction.commandName)} Command` : 'Error',
       color: 16711680,
       description: `uuid: ${uuid()}\nError: ${error.message ? error.message : 'Unexpected Error'}`,
+      fields: interaction
+        ? [
+            {
+              name: 'User',
+              value: interaction.user.username,
+              inline: true,
+            },
+            {
+              name: 'User ID',
+              value: interaction.user.id,
+              inline: true,
+            },
+            {
+              name: 'Channel',
+              value: interactionChannel ? interactionChannel.name : '-',
+              inline: true,
+            },
+            {
+              name: 'Channel ID',
+              value: interaction.channelId,
+              inline: true,
+            },
+            {
+              name: 'Guild',
+              value: interaction.guild ? interaction.guild.name : '-',
+              inline: true,
+            },
+            {
+              name: 'Guild ID',
+              value: interaction.guildId ? interaction.guildId : '-',
+              inline: true,
+            },
+          ]
+        : undefined,
     };
     const notificationWebhook = new WebhookClient({ url: ERROR_NOTIFICATION_WEBHOOK_URL });
     await notificationWebhook.send({

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { APIEmbed, Client, Guild, WebhookClient } from 'discord.js';
-import { isEmpty } from 'lodash';
+import { capitalize, isEmpty } from 'lodash';
 import { ERROR_NOTIFICATION_WEBHOOK_URL } from '../config/environment';
 
 export const serverNotificationEmbed = async ({
@@ -47,9 +47,19 @@ export const serverNotificationEmbed = async ({
   return embed;
 };
 
-export const sendErrorLog = async (error: any) => {
+export const sendErrorLog = async ({
+  error,
+  commandName,
+}: {
+  error: any;
+  commandName?: string;
+}) => {
   console.log(error);
   if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
+    const embed = {
+      title: commandName ? `Error | ${capitalize(commandName)} Command` : 'Error',
+      color: 16711680,
+    };
     const notificationWebhook = new WebhookClient({ url: ERROR_NOTIFICATION_WEBHOOK_URL });
     await notificationWebhook.send({
       content: error.message ? error.message : 'Oops something went wrong D:',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,6 @@
-import { APIEmbed, Client, Guild } from 'discord.js';
+import { APIEmbed, Client, Guild, WebhookClient } from 'discord.js';
+import { isEmpty } from 'lodash';
+import { ERROR_NOTIFICATION_WEBHOOK_URL } from '../config/environment';
 
 export const serverNotificationEmbed = async ({
   app,
@@ -43,4 +45,16 @@ export const serverNotificationEmbed = async ({
     ],
   };
   return embed;
+};
+
+export const sendErrorLog = async (error: any) => {
+  console.log(error);
+  if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
+    const notificationWebhook = new WebhookClient({ url: ERROR_NOTIFICATION_WEBHOOK_URL });
+    await notificationWebhook.send({
+      content: error.message ? error.message : 'Oops something went wrong D:',
+      username: 'My App Error Notification',
+      avatarURL: '',
+    });
+  }
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -66,6 +66,7 @@ export const sendErrorLog = async ({
   error: any;
   interaction?: CommandInteraction;
 }) => {
+  console.error(error);
   const errorID = uuid();
   if (interaction) {
     const errorEmbed = {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,7 @@
-import { APIEmbed, Client, Guild, WebhookClient } from 'discord.js';
+import { APIEmbed, Client, CommandInteraction, Guild, WebhookClient } from 'discord.js';
 import { capitalize, isEmpty } from 'lodash';
 import { ERROR_NOTIFICATION_WEBHOOK_URL } from '../config/environment';
+import { v4 as uuid } from 'uuid';
 
 export const serverNotificationEmbed = async ({
   app,
@@ -49,20 +50,21 @@ export const serverNotificationEmbed = async ({
 
 export const sendErrorLog = async ({
   error,
-  commandName,
+  interaction,
 }: {
   error: any;
-  commandName?: string;
+  interaction?: CommandInteraction;
 }) => {
   console.log(error);
   if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
     const embed = {
-      title: commandName ? `Error | ${capitalize(commandName)} Command` : 'Error',
+      title: interaction ? `Error | ${capitalize(interaction.commandName)} Command` : 'Error',
       color: 16711680,
+      description: `uuid: ${uuid()}\nError: ${error.message ? error.message : 'Unexpected Error'}`,
     };
     const notificationWebhook = new WebhookClient({ url: ERROR_NOTIFICATION_WEBHOOK_URL });
     await notificationWebhook.send({
-      content: error.message ? error.message : 'Oops something went wrong D:',
+      embeds: [embed],
       username: 'My App Error Notification',
       avatarURL: '',
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4014,6 +4014,11 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,6 +1101,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/uuid@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"
+  integrity sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==
+
 "@types/ws@^8.5.4":
   version "8.5.4"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz#bb10e36116d6e570dd943735f86c933c1587b8a5"


### PR DESCRIPTION
#### Context
This adds error handling and logging to the app. Basically it will send an embed with metadata of the error to a specified discord webhook url. Also if the error originated from a command, we'll edit the interaction with an error embed instead so there is some visibility. 

A bit of a headache trying to type errors since the error object we're getting will always be unknown by default. Now I could painstakingly find out each of the errors thrown by each of the packages but I'm lazy and it's honestly a waste of time. I much rather commit a sin and assume that the error object is `any` and go on our way 

<img width="533" alt="image" src="https://user-images.githubusercontent.com/42207245/230728007-52fa5ade-e700-40b7-a73a-aa3dd1f6e7e9.png">

#### Change
- Create send error helper
- Install uuid
- Add error handling to relevant functions