### PR TITLE
Add mixpanel analytics tracking

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1,7 +1,9 @@
 import { Client, GatewayIntentBits } from 'discord.js';
-import { BOT_TOKEN } from './config/environment';
+import { BOT_TOKEN, MIXPANEL_ID } from './config/environment';
 import { registerEventHandlers } from './events/events';
 import { sendErrorLog } from './utils/helpers';
+import Mixpanel from 'mixpanel';
+import { isEmpty } from 'lodash';
 
 const app: Client = new Client({
   intents: [GatewayIntentBits.Guilds],
@@ -10,7 +12,8 @@ const app: Client = new Client({
 const initialize = async (): Promise<void> => {
   try {
     await app.login(BOT_TOKEN);
-    registerEventHandlers({ app });
+    const mixpanel = MIXPANEL_ID && !isEmpty(MIXPANEL_ID) ? Mixpanel.init(MIXPANEL_ID) : null;
+    registerEventHandlers({ app, mixpanel });
   } catch (error) {
     sendErrorLog({ error });
   }

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,5 +1,6 @@
 import { Client } from 'discord.js';
 import fs from 'fs';
+import { Mixpanel } from 'mixpanel';
 import path from 'path';
 import { AppCommands, getApplicationCommands } from '../commands/commands';
 import { sendErrorLog } from '../utils/helpers';
@@ -8,6 +9,7 @@ const appCommands = getApplicationCommands();
 
 interface Props {
   app: Client;
+  mixpanel: Mixpanel | null;
 }
 type ExportedEventModule = {
   default: (data: EventModule) => void;
@@ -15,8 +17,9 @@ type ExportedEventModule = {
 export type EventModule = {
   app: Client;
   appCommands?: AppCommands;
+  mixpanel?: Mixpanel | null;
 };
-export function registerEventHandlers({ app }: Props): void {
+export function registerEventHandlers({ app, mixpanel }: Props): void {
   const loadModules = (directoryPath: string) => {
     fs.readdir(directoryPath, { withFileTypes: true }, (error, files) => {
       if (error) {
@@ -31,7 +34,7 @@ export function registerEventHandlers({ app }: Props): void {
           if (file.name === 'index.js') {
             const modulePath = `.${filePath.replace('dist/events', '')}`;
             const currentModule = require(modulePath) as ExportedEventModule;
-            currentModule.default({ app, appCommands });
+            currentModule.default({ app, appCommands, mixpanel });
           }
         });
     });

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,9 +1,10 @@
 import { CacheType, Interaction } from 'discord.js';
 import { AppCommands } from '../../commands/commands';
+import { sendCommandEvent } from '../../services/analytics';
 import { sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
 
-export default function ({ app, appCommands }: EventModule) {
+export default function ({ app, appCommands, mixpanel }: EventModule) {
   app.on('interactionCreate', async (interaction: Interaction<CacheType>) => {
     try {
       if (!interaction.inGuild() || !appCommands) return;
@@ -12,6 +13,14 @@ export default function ({ app, appCommands }: EventModule) {
         const { commandName } = interaction;
         const command = appCommands[commandName as keyof AppCommands];
         command && (await command.execute({ interaction, app }));
+        mixpanel &&
+          sendCommandEvent({
+            user: interaction.user,
+            channel: interaction.channel,
+            guild: interaction.guild,
+            command: commandName,
+            client: mixpanel,
+          });
       }
       //Maybe add buttons, selections and modal handlers here eventually
     } catch (error) {

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -9,7 +9,7 @@ type CommandEvent = {
   guild: Guild | null;
   command: string;
   options?: string;
-  properties?: Object;
+  properties?: object;
 };
 type UserProfile = {
   client: Mixpanel;

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,0 +1,39 @@
+import { Guild, TextBasedChannel, User } from 'discord.js';
+import { capitalize } from 'lodash';
+import { Mixpanel } from 'mixpanel';
+
+type CommandEvent = {
+  user: User;
+  channel: TextBasedChannel;
+  guild: Guild;
+  command: string;
+  client: Mixpanel;
+  options?: string;
+  properties?: Object;
+};
+
+export function sendCommandEvent({
+  user,
+  channel,
+  guild,
+  command,
+  client,
+  options,
+  properties,
+}: CommandEvent): void {
+  if (channel.isDMBased()) return;
+  const eventName = `Use ${capitalize(command)} Command`;
+
+  client.track(eventName, {
+    distinct_id: user.id,
+    user: user.tag,
+    user_name: user.username,
+    channel: channel.name,
+    channel_id: channel.id,
+    guild: guild.name,
+    guild_id: guild.id,
+    command: command,
+    arguments: options ? options : 'none',
+    ...properties,
+  });
+}

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,17 +1,46 @@
-import { Guild, TextBasedChannel, User } from 'discord.js';
+import {
+  DMChannel,
+  Guild,
+  PartialDMChannel,
+  PartialGroupDMChannel,
+  TextBasedChannel,
+  User,
+} from 'discord.js';
 import { capitalize } from 'lodash';
 import { Mixpanel } from 'mixpanel';
 
 type CommandEvent = {
+  client: Mixpanel;
   user: User;
   channel: TextBasedChannel;
   guild: Guild;
   command: string;
-  client: Mixpanel;
   options?: string;
   properties?: Object;
 };
+type UserProfile = {
+  client: Mixpanel;
+  user: User;
+  channel: Exclude<TextBasedChannel, DMChannel | PartialDMChannel | PartialGroupDMChannel>;
+  guild: Guild;
+  command?: string;
+};
 
+function setUserProfile({ client, user, channel, guild, command }: UserProfile) {
+  client.people.set(user.id, {
+    $name: user.username,
+    $created: user.createdAt.toISOString(),
+    tag: user.tag,
+    guild: guild.name,
+    guild_id: guild.id,
+  });
+  client.people.set_once(user.id, {
+    first_used: new Date().toISOString(), //Unfortunately this is only after v2.5
+    first_command: command,
+    first_used_in_guild: guild.name,
+    first_used_in_channel: channel.name,
+  });
+}
 export function sendCommandEvent({
   user,
   channel,
@@ -22,6 +51,7 @@ export function sendCommandEvent({
   properties,
 }: CommandEvent): void {
   if (channel.isDMBased()) return;
+  setUserProfile({ client, user, guild, channel, command });
   const eventName = `Use ${capitalize(command)} Command`;
 
   client.track(eventName, {


### PR DESCRIPTION
#### Context
This wires up handlers for [mixpanel](https://mixpanel.com/home/) which will track product usage. Basically analytics for when a user triggers commands, buttons, etc tho currently this is only setup to track commands. Pretty much don't have to think about this anymore once it's merged since it will automatically track anytime a command gets triggered, even newly created ones.

You'd only need a mixpanel project token to be able to use this. Leaving `MIXPANEL_ID` as an empty string or undefined will ignore tracking

![image](https://user-images.githubusercontent.com/42207245/230961247-b31933ef-7d33-4b73-8144-fad6924c719b.png)

Example of how this data can be potentially visualised
![image](https://user-images.githubusercontent.com/42207245/230961094-87a44f6e-aa17-43ad-b342-841718a4c7ff.png)

#### Change
- Create analytics file
- Wire up event command handler
