### PR TITLE
Add production deployment workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,24 @@
+name: deploy/prod
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Add your deployment process here; personally I deploy it to a DigitalOcean droplet
+
+      - name: Send notification to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_NOTIFICATION_WEBHOOK }}
+          DISCORD_USERNAME: 'My App Release Notification'
+          DISCORD_AVATAR: ''
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: 'Successfully deployed `${{ github.ref_name }}` to production'


### PR DESCRIPTION
#### Context
This creates a workflow for deploying the app to a production instance whenever a release gets published. I just added the boilerplate file for it and left the deployment step blank as I would think it'll differ a lot for every app. This is the only time we'd actually make use of github secrets. Right now it's only needing the discord webhook url but you'd generally also add the instance credentials passed in as well

Example of how the notification would look like after deployment:
<img width="406" alt="image" src="https://user-images.githubusercontent.com/42207245/231200748-48757cef-e4f5-478d-ae80-92dde87da107.png">


#### Change
- Create yaml file
