### PR TITLE
Create default commands

### DIFF
--- a/src/commands/about/index.test.ts
+++ b/src/commands/about/index.test.ts
@@ -1,0 +1,50 @@
+import { generateAboutEmbed } from '.';
+import { BOT_UPDATED_AT, BOT_VERSION } from '../../version';
+
+describe('About Command', () => {
+  it('generates an embed correctly', () => {
+    const embed = generateAboutEmbed();
+
+    expect(embed).not.toBeUndefined();
+  });
+  it('displays the correct fields in the embed', () => {
+    const embed = generateAboutEmbed();
+
+    expect(embed.title).not.toBeUndefined();
+    expect(embed.description).not.toBeUndefined();
+    expect(embed.color).not.toBeUndefined();
+    expect(embed.thumbnail).not.toBeUndefined();
+    expect(embed.thumbnail && embed.thumbnail.url).not.toBeUndefined();
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields.length).toBe(6);
+  });
+  it('displays the correct description', () => {
+    const embed = generateAboutEmbed();
+
+    expect(embed).not.toBeUndefined();
+    expect(embed.description).not.toBeUndefined();
+  });
+  it('dispays the correct Date Created field if client is not passed in', () => {
+    const embed = generateAboutEmbed();
+
+    expect(embed).not.toBeUndefined();
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[1].name).toBe('Date Created');
+    expect(embed.fields && embed.fields[1].value).toBe('N/A');
+  });
+  it('displays the correct bot version', () => {
+    const embed = generateAboutEmbed();
+
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[2].name).toBe('Version');
+    expect(embed.fields && embed.fields[2].value).toBe(BOT_VERSION);
+  });
+  it('displays the correct Last Updated field', () => {
+    const embed = generateAboutEmbed();
+
+    expect(embed).not.toBeUndefined();
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[4].name).toBe('Last Updated');
+    expect(embed.fields && embed.fields[4].value).toBe(BOT_UPDATED_AT);
+  });
+});

--- a/src/commands/about/index.ts
+++ b/src/commands/about/index.ts
@@ -1,0 +1,64 @@
+import { APIEmbed, Client, SlashCommandBuilder } from 'discord.js';
+import { BOT_UPDATED_AT, BOT_VERSION } from '../../version';
+import { AppCommand, AppCommandOptions } from '../commands';
+import { format } from 'date-fns';
+import { sendErrorLog } from '../../utils/helpers';
+
+export const generateAboutEmbed = (app?: Client): APIEmbed => {
+  const embed = {
+    title: 'Info',
+    description:
+      "Hi there! This is where you'd want to explain what your App does and any other cool stuff about it! :D",
+    color: 55296,
+    thumbnail: {
+      url: 'https://cdn.discordapp.com/attachments/1089616880576245853/1094559253395689562/mitsuha.jpg',
+    },
+    fields: [
+      {
+        name: 'Creator',
+        value: '-',
+        inline: true,
+      },
+      {
+        name: 'Date Created',
+        value:
+          app && app.application ? format(app.application.createdTimestamp, 'dd-MM-yyyy') : 'N/A',
+        inline: true,
+      },
+      {
+        name: 'Version',
+        value: BOT_VERSION,
+        inline: true,
+      },
+      {
+        name: 'Library',
+        value: 'discord.js',
+        inline: true,
+      },
+      {
+        name: 'Last Updated',
+        value: BOT_UPDATED_AT,
+        inline: true,
+      },
+      {
+        name: 'Support Server',
+        value: '-',
+        inline: true,
+      },
+    ],
+  };
+  return embed;
+};
+export default {
+  data: new SlashCommandBuilder()
+    .setName('about')
+    .setDescription('Displays information about My App'),
+  async execute({ interaction, app }: AppCommandOptions) {
+    try {
+      const embed = generateAboutEmbed(app);
+      await interaction.reply({ embeds: [embed] });
+    } catch (error) {
+      sendErrorLog({ error, interaction });
+    }
+  },
+} as AppCommand;

--- a/src/commands/about/index.ts
+++ b/src/commands/about/index.ts
@@ -50,7 +50,6 @@ export const generateAboutEmbed = (app?: Client): APIEmbed => {
   return embed;
 };
 export default {
-  commandType: 'Information',
   data: new SlashCommandBuilder()
     .setName('about')
     .setDescription('Displays information about My App'),

--- a/src/commands/about/index.ts
+++ b/src/commands/about/index.ts
@@ -50,6 +50,7 @@ export const generateAboutEmbed = (app?: Client): APIEmbed => {
   return embed;
 };
 export default {
+  commandType: 'Information',
   data: new SlashCommandBuilder()
     .setName('about')
     .setDescription('Displays information about My App'),

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -5,9 +5,13 @@ import path from 'path';
 
 export type AppCommands = {
   hello?: AppCommand;
+  about?: AppCommand;
+  help?: AppCommand;
+  invite?: AppCommand;
 };
 export type AppCommand = {
   data: SlashCommandBuilder;
+  commandType?: string;
   execute: (data: AppCommandOptions) => Promise<void>;
 };
 export type AppCommandOptions = {

--- a/src/commands/hello/index.test.ts
+++ b/src/commands/hello/index.test.ts
@@ -11,6 +11,5 @@ describe('Hello Command', () => {
 
     expect(embed.description).not.toBeUndefined();
     expect(embed.color).not.toBeUndefined();
-    expect(embed.fields).not.toBeUndefined();
   });
 });

--- a/src/commands/hello/index.test.ts
+++ b/src/commands/hello/index.test.ts
@@ -12,6 +12,5 @@ describe('Hello Command', () => {
     expect(embed.description).not.toBeUndefined();
     expect(embed.color).not.toBeUndefined();
     expect(embed.fields).not.toBeUndefined();
-    expect(embed.fields && embed.fields.length).toBe(3);
   });
 });

--- a/src/commands/hello/index.ts
+++ b/src/commands/hello/index.ts
@@ -4,28 +4,12 @@ import { AppCommand, AppCommandOptions } from '../commands';
 
 export function generateHelloEmbed(): APIEmbed {
   const embed: APIEmbed = {
-    title: 'Hello Command',
+    title: 'Hello',
     color: 55296,
     description: 'Hi there! (◕ᴗ◕✿)',
     thumbnail: {
       url: 'https://cdn.discordapp.com/attachments/1089616880576245853/1094559253395689562/mitsuha.jpg',
     },
-    fields: [
-      {
-        name: 'Field 1',
-        value: 'This is a normal field!',
-      },
-      {
-        name: 'Field 2',
-        value: 'This is an inline field!',
-        inline: true,
-      },
-      {
-        name: 'Field 3',
-        value: 'This is an inline field too!',
-        inline: true,
-      },
-    ],
   };
   return embed;
 }

--- a/src/commands/help/index.test.ts
+++ b/src/commands/help/index.test.ts
@@ -1,0 +1,17 @@
+import { generateHelpEmbed } from '.';
+
+describe('Help Command', () => {
+  it('generates an embed correctly', () => {
+    const embed = generateHelpEmbed();
+
+    expect(embed).not.toBeUndefined();
+  });
+  it('displays the correct fields in the embed', () => {
+    const embed = generateHelpEmbed();
+
+    expect(embed.description).not.toBeUndefined();
+    expect(embed.color).not.toBeUndefined();
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields.length).toBe(1);
+  });
+});

--- a/src/commands/help/index.ts
+++ b/src/commands/help/index.ts
@@ -17,7 +17,6 @@ export const generateHelpEmbed = (): APIEmbed => {
   return embed;
 };
 export default {
-  commandType: 'Information',
   data: new SlashCommandBuilder().setName('help').setDescription('Directory hub of commands'),
   async execute({ interaction }: AppCommandOptions) {
     try {

--- a/src/commands/help/index.ts
+++ b/src/commands/help/index.ts
@@ -17,6 +17,7 @@ export const generateHelpEmbed = (): APIEmbed => {
   return embed;
 };
 export default {
+  commandType: 'Information',
   data: new SlashCommandBuilder().setName('help').setDescription('Directory hub of commands'),
   async execute({ interaction }: AppCommandOptions) {
     try {

--- a/src/commands/help/index.ts
+++ b/src/commands/help/index.ts
@@ -1,0 +1,29 @@
+import { APIEmbed, SlashCommandBuilder } from 'discord.js';
+import { codeMark, sendErrorLog } from '../../utils/helpers';
+import { AppCommand, AppCommandOptions } from '../commands';
+
+export const generateHelpEmbed = (): APIEmbed => {
+  const embed = {
+    color: 55296,
+    description: 'Below you can see all the commands that I know!',
+    fields: [
+      {
+        name: 'Information',
+        value: `${codeMark('about')}, ${codeMark('help')}, ${codeMark('invite')}`,
+        inline: false,
+      },
+    ],
+  };
+  return embed;
+};
+export default {
+  data: new SlashCommandBuilder().setName('help').setDescription('Directory hub of commands'),
+  async execute({ interaction }: AppCommandOptions) {
+    try {
+      const embed = generateHelpEmbed();
+      await interaction.reply({ embeds: [embed] });
+    } catch (error) {
+      sendErrorLog({ error, interaction });
+    }
+  },
+} as AppCommand;

--- a/src/commands/invite/index.test.ts
+++ b/src/commands/invite/index.test.ts
@@ -1,0 +1,15 @@
+import { generateInviteEmbed } from '.';
+
+describe('Invite Command', () => {
+  it('generates an embed correctly', () => {
+    const embed = generateInviteEmbed();
+
+    expect(embed).not.toBeUndefined();
+  });
+  it('displays the correct fields in the embed', () => {
+    const embed = generateInviteEmbed();
+
+    expect(embed.description).not.toBeUndefined();
+    expect(embed.color).not.toBeUndefined();
+  });
+});

--- a/src/commands/invite/index.ts
+++ b/src/commands/invite/index.ts
@@ -1,0 +1,25 @@
+import { AppCommand, AppCommandOptions } from '../commands';
+import { APIEmbed, hyperlink, SlashCommandBuilder } from 'discord.js';
+import { sendErrorLog } from '../../utils/helpers';
+
+export const generateInviteEmbed = (): APIEmbed => {
+  const embed = {
+    description: hyperlink('Add me to your servers! (◕ᴗ◕✿)', ''),
+    color: 55296,
+  };
+  return embed;
+};
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('invite')
+    .setDescription('Generates an invite link for My App'),
+  async execute({ interaction }: AppCommandOptions) {
+    try {
+      const embed = generateInviteEmbed();
+      await interaction.reply({ embeds: [embed] });
+    } catch (error) {
+      sendErrorLog({ error, interaction });
+    }
+  },
+} as AppCommand;

--- a/src/commands/invite/index.ts
+++ b/src/commands/invite/index.ts
@@ -11,6 +11,7 @@ export const generateInviteEmbed = (): APIEmbed => {
 };
 
 export default {
+  commandType: 'Information',
   data: new SlashCommandBuilder()
     .setName('invite')
     .setDescription('Generates an invite link for My App'),

--- a/src/commands/invite/index.ts
+++ b/src/commands/invite/index.ts
@@ -11,7 +11,6 @@ export const generateInviteEmbed = (): APIEmbed => {
 };
 
 export default {
-  commandType: 'Information',
   data: new SlashCommandBuilder()
     .setName('invite')
     .setDescription('Generates an invite link for My App'),


### PR DESCRIPTION
#### Context
Adds a couple of commands that I normally have in every app I create. `About`, `help`, and `invite`. I'm a bit lazy in creating these again and again for my future apps so adding these in

<img width="614" alt="image" src="https://user-images.githubusercontent.com/42207245/232244619-84bd42b6-42b1-40f2-9ce5-3df29c91d25a.png">

#### Change
- Create about command
- Create help command
- Create invite command
