### PR TITLE
Refactor command implementation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: >
           echo "export const ENV = 'dev'; export const BOT_TOKEN = ''; export const MIXPANEL_ID = ''; export const TOP_GG_TOKEN = '';
           export const GUILD_IDS = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const USE_DATABASE = false; 
-          export const ERROR_NOTIFICATION_WEBHOOK_URL = '';" 
+          export const ERROR_NOTIFICATION_WEBHOOK_URL = ''; export const BOOT_NOTIFICATION_CHANNEL_ID = '';" 
           > src/config/environment.ts
 
       - name: Load database config
@@ -75,7 +75,7 @@ jobs:
         run: >
           echo "export const ENV = 'dev'; export const BOT_TOKEN = ''; export const MIXPANEL_ID = ''; export const TOP_GG_TOKEN = '';
           export const GUILD_IDS = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const USE_DATABASE = false; 
-          export const ERROR_NOTIFICATION_WEBHOOK_URL = '';" 
+          export const ERROR_NOTIFICATION_WEBHOOK_URL = ''; export const BOOT_NOTIFICATION_CHANNEL_ID = '';" 
           > src/config/environment.ts
 
       - name: Load database config

--- a/src/commands/about/index.ts
+++ b/src/commands/about/index.ts
@@ -50,6 +50,7 @@ export const generateAboutEmbed = (app?: Client): APIEmbed => {
   return embed;
 };
 export default {
+  commandType: 'Information',
   data: new SlashCommandBuilder()
     .setName('about')
     .setDescription('Displays information about My App'),

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -11,6 +11,7 @@ export type AppCommand = {
 export type AppCommandOptions = {
   interaction: CommandInteraction;
   app: Client;
+  appCommands?: AppCommand[];
 };
 type ExportedAppCommand = {
   default: AppCommand;

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -3,12 +3,6 @@ import { Client, CommandInteraction } from 'discord.js';
 import fs from 'fs';
 import path from 'path';
 
-export type AppCommands = {
-  hello?: AppCommand;
-  about?: AppCommand;
-  help?: AppCommand;
-  invite?: AppCommand;
-};
 export type AppCommand = {
   data: SlashCommandBuilder;
   commandType?: string;
@@ -21,8 +15,9 @@ export type AppCommandOptions = {
 type ExportedAppCommand = {
   default: AppCommand;
 };
-export function getApplicationCommands(): AppCommands {
-  const appCommands: AppCommands = {};
+export function getApplicationCommands(): AppCommand[] {
+  const appCommands: AppCommand[] = [];
+
   const loadModules = (directoryPath: string) => {
     const files = fs.readdirSync(directoryPath, { withFileTypes: true });
     files.forEach((file) => {
@@ -33,8 +28,7 @@ export function getApplicationCommands(): AppCommands {
       if (file.name === 'index.js') {
         const modulePath = `./${filePath.replace('dist/commands/', '')}`;
         const currentModule = require(modulePath) as ExportedAppCommand;
-        appCommands[directoryPath.replace('dist/commands/', '') as keyof AppCommands] =
-          currentModule.default;
+        appCommands.push(currentModule.default);
       }
     });
   };

--- a/src/commands/help/index.test.ts
+++ b/src/commands/help/index.test.ts
@@ -11,7 +11,6 @@ describe('Help Command', () => {
 
     expect(embed.description).not.toBeUndefined();
     expect(embed.color).not.toBeUndefined();
-    expect(embed.fields).not.toBeUndefined();
-    expect(embed.fields && embed.fields.length).toBe(1);
   });
+  //TODO: Test command fields when discordjs figures out a way to mock data for tests
 });

--- a/src/commands/help/index.ts
+++ b/src/commands/help/index.ts
@@ -11,7 +11,13 @@ export const generateHelpEmbed = (appCommands?: AppCommand[]): APIEmbed => {
     const commandValues = reduce(
       appCommands,
       (accumulator, value) => {
-        return `${accumulator}${isEmpty(accumulator) ? '' : ','} ${inlineCode(value.data.name)}`;
+        return `${accumulator}${isEmpty(accumulator) || value.commandType !== type ? '' : ', '}${
+          value.commandType === type
+            ? inlineCode(value.data.name)
+            : !value.commandType && type === 'Others'
+            ? inlineCode(value.data.name)
+            : ''
+        }`;
       },
       ''
     );
@@ -29,6 +35,7 @@ export const generateHelpEmbed = (appCommands?: AppCommand[]): APIEmbed => {
   return embed;
 };
 export default {
+  commandType: 'Information',
   data: new SlashCommandBuilder().setName('help').setDescription('Directory hub of commands'),
   async execute({ interaction, appCommands }: AppCommandOptions) {
     try {

--- a/src/commands/help/index.ts
+++ b/src/commands/help/index.ts
@@ -1,5 +1,5 @@
-import { APIEmbed, SlashCommandBuilder } from 'discord.js';
-import { codeMark, sendErrorLog } from '../../utils/helpers';
+import { APIEmbed, inlineCode, SlashCommandBuilder } from 'discord.js';
+import { sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
 export const generateHelpEmbed = (): APIEmbed => {
@@ -9,7 +9,7 @@ export const generateHelpEmbed = (): APIEmbed => {
     fields: [
       {
         name: 'Information',
-        value: `${codeMark('about')}, ${codeMark('help')}, ${codeMark('invite')}`,
+        value: `${inlineCode('about')}, ${inlineCode('help')}, ${inlineCode('invite')}`,
         inline: false,
       },
     ],

--- a/src/commands/help/index.ts
+++ b/src/commands/help/index.ts
@@ -1,26 +1,38 @@
 import { APIEmbed, inlineCode, SlashCommandBuilder } from 'discord.js';
+import { isEmpty, reduce, uniq } from 'lodash';
 import { sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
-export const generateHelpEmbed = (): APIEmbed => {
+export const generateHelpEmbed = (appCommands?: AppCommand[]): APIEmbed => {
+  const commandTypes = uniq(
+    appCommands?.map((command) => (command.commandType ? command.commandType : 'Others'))
+  );
+  const commandFields = commandTypes.map((type) => {
+    const commandValues = reduce(
+      appCommands,
+      (accumulator, value) => {
+        return `${accumulator}${isEmpty(accumulator) ? '' : ','} ${inlineCode(value.data.name)}`;
+      },
+      ''
+    );
+    return {
+      name: type,
+      value: commandValues,
+      inline: false,
+    };
+  });
   const embed = {
     color: 55296,
     description: 'Below you can see all the commands that I know!',
-    fields: [
-      {
-        name: 'Information',
-        value: `${inlineCode('about')}, ${inlineCode('help')}, ${inlineCode('invite')}`,
-        inline: false,
-      },
-    ],
+    fields: commandFields,
   };
   return embed;
 };
 export default {
   data: new SlashCommandBuilder().setName('help').setDescription('Directory hub of commands'),
-  async execute({ interaction }: AppCommandOptions) {
+  async execute({ interaction, appCommands }: AppCommandOptions) {
     try {
-      const embed = generateHelpEmbed();
+      const embed = generateHelpEmbed(appCommands);
       await interaction.reply({ embeds: [embed] });
     } catch (error) {
       sendErrorLog({ error, interaction });

--- a/src/commands/invite/index.ts
+++ b/src/commands/invite/index.ts
@@ -11,6 +11,7 @@ export const generateInviteEmbed = (): APIEmbed => {
 };
 
 export default {
+  commandType: 'Information',
   data: new SlashCommandBuilder()
     .setName('invite')
     .setDescription('Generates an invite link for My App'),

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -2,7 +2,7 @@ import { Client } from 'discord.js';
 import fs from 'fs';
 import { Mixpanel } from 'mixpanel';
 import path from 'path';
-import { AppCommands, getApplicationCommands } from '../commands/commands';
+import { AppCommand, getApplicationCommands } from '../commands/commands';
 import { sendErrorLog } from '../utils/helpers';
 
 const appCommands = getApplicationCommands();
@@ -16,7 +16,7 @@ type ExportedEventModule = {
 };
 export type EventModule = {
   app: Client;
-  appCommands?: AppCommands;
+  appCommands?: AppCommand[];
   mixpanel?: Mixpanel | null;
 };
 export function registerEventHandlers({ app, mixpanel }: Props): void {

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -11,7 +11,7 @@ export default function ({ app, appCommands, mixpanel }: EventModule) {
       if (interaction.isCommand()) {
         const { commandName } = interaction;
         const command = appCommands.find((command) => command.data.name === commandName);
-        command && (await command.execute({ interaction, app }));
+        command && (await command.execute({ interaction, app, appCommands }));
         mixpanel &&
           sendCommandEvent({
             user: interaction.user,

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,26 +1,24 @@
 import { CacheType, Interaction } from 'discord.js';
-import { AppCommands } from '../../commands/commands';
-import { sendCommandEvent } from '../../services/analytics';
 import { sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
 
-export default function ({ app, appCommands, mixpanel }: EventModule) {
+export default function ({ app, appCommands }: EventModule) {
   app.on('interactionCreate', async (interaction: Interaction<CacheType>) => {
     try {
       if (!interaction.inGuild() || !appCommands) return;
 
       if (interaction.isCommand()) {
-        const { commandName } = interaction;
-        const command = appCommands[commandName as keyof AppCommands];
-        command && (await command.execute({ interaction, app }));
-        mixpanel &&
-          sendCommandEvent({
-            user: interaction.user,
-            channel: interaction.channel,
-            guild: interaction.guild,
-            command: commandName,
-            client: mixpanel,
-          });
+        // const { commandName } = interaction;
+        // const command = appCommands[commandName as keyof AppCommands];
+        // command && (await command.execute({ interaction, app }));
+        // mixpanel &&
+        //   sendCommandEvent({
+        //     user: interaction.user,
+        //     channel: interaction.channel,
+        //     guild: interaction.guild,
+        //     command: commandName,
+        //     client: mixpanel,
+        //   });
       }
       //Maybe add buttons, selections and modal handlers here eventually
     } catch (error) {

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,24 +1,25 @@
 import { CacheType, Interaction } from 'discord.js';
+import { sendCommandEvent } from '../../services/analytics';
 import { sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
 
-export default function ({ app, appCommands }: EventModule) {
+export default function ({ app, appCommands, mixpanel }: EventModule) {
   app.on('interactionCreate', async (interaction: Interaction<CacheType>) => {
     try {
       if (!interaction.inGuild() || !appCommands) return;
 
       if (interaction.isCommand()) {
-        // const { commandName } = interaction;
-        // const command = appCommands[commandName as keyof AppCommands];
-        // command && (await command.execute({ interaction, app }));
-        // mixpanel &&
-        //   sendCommandEvent({
-        //     user: interaction.user,
-        //     channel: interaction.channel,
-        //     guild: interaction.guild,
-        //     command: commandName,
-        //     client: mixpanel,
-        //   });
+        const { commandName } = interaction;
+        const command = appCommands.find((command) => command.data.name === commandName);
+        command && (await command.execute({ interaction, app }));
+        mixpanel &&
+          sendCommandEvent({
+            user: interaction.user,
+            channel: interaction.channel,
+            guild: interaction.guild,
+            command: commandName,
+            client: mixpanel,
+          });
       }
       //Maybe add buttons, selections and modal handlers here eventually
     } catch (error) {

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -9,28 +9,22 @@ const rest = new REST({ version: '9' }).setToken(BOT_TOKEN);
 
 const registerApplicationCommands = async (commands?: AppCommand[]) => {
   if (!commands) return;
-  console.log(commands);
-  // const commandList = Object.keys(commands)
-  //   .map((key) => {
-  //     const commandKey = commands[key as keyof AppCommands];
-  //     if (commandKey) return commandKey.data;
-  //   })
-  //   .map((command) => command && command.toJSON());
-  // console.log(commandList);
+  const commandList = commands.map((command) => command.data.toJSON());
+
   try {
     if (ENV === 'dev') {
       if (GUILD_IDS) {
         //Registering guild-only commands to the bot; I like to use a different bot for dev purposes
         //TODO: Change id here to placeholder
         await rest.put(Routes.applicationGuildCommands('929421200797626388', GUILD_IDS), {
-          body: [],
+          body: commandList,
         });
         console.log('Successfully registered guild application commands');
       }
     } else {
       //Registering global commands for the bot i.e. every guild will see the commands; I mostly just use this in production
       //TODO: Change id here to placeholder
-      await rest.put(Routes.applicationCommands('518196430104428579'), { body: [] });
+      await rest.put(Routes.applicationCommands('518196430104428579'), { body: commandList });
       console.log('Successfully registered global application commands');
     }
   } catch (error) {

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -1,6 +1,12 @@
 import { REST, Routes } from 'discord.js';
 import { AppCommands } from '../../commands/commands';
-import { BOT_TOKEN, ENV, GUILD_IDS, USE_DATABASE } from '../../config/environment';
+import {
+  BOOT_NOTIFICATION_CHANNEL_ID,
+  BOT_TOKEN,
+  ENV,
+  GUILD_IDS,
+  USE_DATABASE,
+} from '../../config/environment';
 import { createGuildTable, populateGuilds } from '../../services/database';
 import { sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
@@ -46,6 +52,11 @@ export default function ({ app, appCommands }: EventModule) {
         await populateGuilds(app.guilds.cache);
       }
       console.log("I'm booting up! (◕ᴗ◕✿)");
+      const bootNotificationChannel =
+        BOOT_NOTIFICATION_CHANNEL_ID && app.channels.cache.get(BOOT_NOTIFICATION_CHANNEL_ID);
+      bootNotificationChannel &&
+        bootNotificationChannel.isTextBased() &&
+        (await bootNotificationChannel.send("I'm booting up! (◕ᴗ◕✿)"));
     } catch (error) {
       console.log(error);
     }

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -1,14 +1,8 @@
 import { REST, Routes } from 'discord.js';
 import { AppCommands } from '../../commands/commands';
-import {
-  BOOT_NOTIFICATION_CHANNEL_ID,
-  BOT_TOKEN,
-  ENV,
-  GUILD_IDS,
-  USE_DATABASE,
-} from '../../config/environment';
+import { BOT_TOKEN, ENV, GUILD_IDS, USE_DATABASE } from '../../config/environment';
 import { createGuildTable, populateGuilds } from '../../services/database';
-import { sendErrorLog } from '../../utils/helpers';
+import { sendBootNotification, sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
 
 const rest = new REST({ version: '9' }).setToken(BOT_TOKEN);
@@ -51,12 +45,7 @@ export default function ({ app, appCommands }: EventModule) {
         await createGuildTable();
         await populateGuilds(app.guilds.cache);
       }
-      console.log("I'm booting up! (◕ᴗ◕✿)");
-      const bootNotificationChannel =
-        BOOT_NOTIFICATION_CHANNEL_ID && app.channels.cache.get(BOOT_NOTIFICATION_CHANNEL_ID);
-      bootNotificationChannel &&
-        bootNotificationChannel.isTextBased() &&
-        (await bootNotificationChannel.send("I'm booting up! (◕ᴗ◕✿)"));
+      await sendBootNotification(app);
     } catch (error) {
       console.log(error);
     }

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -1,5 +1,5 @@
 import { REST, Routes } from 'discord.js';
-import { AppCommands } from '../../commands/commands';
+import { AppCommand } from '../../commands/commands';
 import { BOT_TOKEN, ENV, GUILD_IDS, USE_DATABASE } from '../../config/environment';
 import { createGuildTable, populateGuilds } from '../../services/database';
 import { sendBootNotification, sendErrorLog } from '../../utils/helpers';
@@ -7,29 +7,30 @@ import { EventModule } from '../events';
 
 const rest = new REST({ version: '9' }).setToken(BOT_TOKEN);
 
-const registerApplicationCommands = async (commands?: AppCommands) => {
+const registerApplicationCommands = async (commands?: AppCommand[]) => {
   if (!commands) return;
-  const commandList = Object.keys(commands)
-    .map((key) => {
-      const commandKey = commands[key as keyof AppCommands];
-      if (commandKey) return commandKey.data;
-    })
-    .map((command) => command && command.toJSON());
-
+  console.log(commands);
+  // const commandList = Object.keys(commands)
+  //   .map((key) => {
+  //     const commandKey = commands[key as keyof AppCommands];
+  //     if (commandKey) return commandKey.data;
+  //   })
+  //   .map((command) => command && command.toJSON());
+  // console.log(commandList);
   try {
     if (ENV === 'dev') {
       if (GUILD_IDS) {
         //Registering guild-only commands to the bot; I like to use a different bot for dev purposes
         //TODO: Change id here to placeholder
         await rest.put(Routes.applicationGuildCommands('929421200797626388', GUILD_IDS), {
-          body: commandList,
+          body: [],
         });
         console.log('Successfully registered guild application commands');
       }
     } else {
       //Registering global commands for the bot i.e. every guild will see the commands; I mostly just use this in production
       //TODO: Change id here to placeholder
-      await rest.put(Routes.applicationCommands('518196430104428579'), { body: commandList });
+      await rest.put(Routes.applicationCommands('518196430104428579'), { body: [] });
       console.log('Successfully registered global application commands');
     }
   } catch (error) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -8,7 +8,10 @@ import {
   WebhookClient,
 } from 'discord.js';
 import { capitalize, isEmpty } from 'lodash';
-import { ERROR_NOTIFICATION_WEBHOOK_URL } from '../config/environment';
+import {
+  BOOT_NOTIFICATION_CHANNEL_ID,
+  ERROR_NOTIFICATION_WEBHOOK_URL,
+} from '../config/environment';
 import { v4 as uuid } from 'uuid';
 
 export const serverNotificationEmbed = async ({
@@ -122,4 +125,13 @@ export const sendErrorLog = async ({
       avatarURL: '',
     });
   }
+};
+
+export const sendBootNotification = async (app: Client) => {
+  console.log("I'm booting up! (◕ᴗ◕✿)");
+  const bootNotificationChannel =
+    BOOT_NOTIFICATION_CHANNEL_ID && app.channels.cache.get(BOOT_NOTIFICATION_CHANNEL_ID);
+  bootNotificationChannel &&
+    bootNotificationChannel.isTextBased() &&
+    (await bootNotificationChannel.send("I'm booting up! (◕ᴗ◕✿)"));
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,15 +4,12 @@ import {
   CommandInteraction,
   Guild,
   GuildChannel,
+  inlineCode,
   WebhookClient,
 } from 'discord.js';
 import { capitalize, isEmpty } from 'lodash';
 import { ERROR_NOTIFICATION_WEBHOOK_URL } from '../config/environment';
 import { v4 as uuid } from 'uuid';
-
-export const codeMark = (text: string) => {
-  return '`' + text + '`';
-};
 
 export const serverNotificationEmbed = async ({
   app,
@@ -71,8 +68,8 @@ export const sendErrorLog = async ({
   if (interaction) {
     const errorEmbed = {
       description: `Oops something went wrong! D:\n\nError: ${
-        error.message ? codeMark(error.message) : codeMark('Unexpected Error')
-      }\nError ID: ${codeMark(errorID)}`,
+        error.message ? inlineCode(error.message) : inlineCode('Unexpected Error')
+      }\nError ID: ${inlineCode(errorID)}`,
       color: 16711680,
     };
     await interaction.editReply({ embeds: [errorEmbed] });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,6 @@
 import {
   APIEmbed,
+  Channel,
   Client,
   CommandInteraction,
   Guild,
@@ -129,8 +130,10 @@ export const sendErrorLog = async ({
 
 export const sendBootNotification = async (app: Client) => {
   console.log("I'm booting up! (◕ᴗ◕✿)");
-  const bootNotificationChannel =
-    BOOT_NOTIFICATION_CHANNEL_ID && app.channels.cache.get(BOOT_NOTIFICATION_CHANNEL_ID);
+  const bootNotificationChannel: Channel | undefined =
+    BOOT_NOTIFICATION_CHANNEL_ID && !isEmpty(BOOT_NOTIFICATION_CHANNEL_ID)
+      ? app.channels.cache.get(BOOT_NOTIFICATION_CHANNEL_ID)
+      : undefined;
   bootNotificationChannel &&
     bootNotificationChannel.isTextBased() &&
     (await bootNotificationChannel.send("I'm booting up! (◕ᴗ◕✿)"));


### PR DESCRIPTION
#### Context
Wanted to automate the listing of the commands in the help command but I ended up refactoring a couple of other stuff. Mainly the command initialisation and registering it to discord. From what I can remember this was legacy code copied over from one of the old guides of discordjs. Figured it didn't really make sense semantically anymore so refactored them.

Granted this looks more complicated but overall I think it's better

![image](https://user-images.githubusercontent.com/42207245/232327720-58f60365-28c8-420a-8596-711300117b3d.png)

#### Change
- Add booting up notification helper
- Use native formatting helpers
- Refactor app commands to be an array
- Refactor command list register
- Make help embed automated

