### PR TITLE
Refactor database config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Load environment config
         run: >
           echo "export const ENV = 'dev'; export const BOT_TOKEN = ''; export const MIXPANEL_ID = ''; export const TOP_GG_TOKEN = '';
-          export const GUILD_IDS = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const DATABASE_CONFIG = null; 
+          export const GUILD_ID = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const DATABASE_CONFIG = null; 
           export const ERROR_NOTIFICATION_WEBHOOK_URL = ''; export const BOOT_NOTIFICATION_CHANNEL_ID = ''; export const BOT_ID = '';" 
           > src/config/environment.ts
 
@@ -71,7 +71,7 @@ jobs:
       - name: Load environment config
         run: >
           echo "export const ENV = 'dev'; export const BOT_TOKEN = ''; export const MIXPANEL_ID = ''; export const TOP_GG_TOKEN = '';
-          export const GUILD_IDS = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const DATABASE_CONFIG = null;
+          export const GUILD_ID = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const DATABASE_CONFIG = null;
           export const ERROR_NOTIFICATION_WEBHOOK_URL = ''; export const BOOT_NOTIFICATION_CHANNEL_ID = ''; export const BOT_ID = '';"  
           > src/config/environment.ts
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,12 +44,9 @@ jobs:
       - name: Load environment config
         run: >
           echo "export const ENV = 'dev'; export const BOT_TOKEN = ''; export const MIXPANEL_ID = ''; export const TOP_GG_TOKEN = '';
-          export const GUILD_IDS = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const USE_DATABASE = false; 
+          export const GUILD_IDS = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const DATABASE_CONFIG = null; 
           export const ERROR_NOTIFICATION_WEBHOOK_URL = ''; export const BOOT_NOTIFICATION_CHANNEL_ID = ''; export const BOT_ID = '';" 
           > src/config/environment.ts
-
-      - name: Load database config
-        run: echo "export const databaseConfig = {};" > src/config/database.ts
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -74,12 +71,9 @@ jobs:
       - name: Load environment config
         run: >
           echo "export const ENV = 'dev'; export const BOT_TOKEN = ''; export const MIXPANEL_ID = ''; export const TOP_GG_TOKEN = '';
-          export const GUILD_IDS = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const USE_DATABASE = false; 
+          export const GUILD_IDS = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const DATABASE_CONFIG = null;
           export const ERROR_NOTIFICATION_WEBHOOK_URL = ''; export const BOOT_NOTIFICATION_CHANNEL_ID = ''; export const BOT_ID = '';"  
           > src/config/environment.ts
-
-      - name: Load database config
-        run: echo "export const databaseConfig = {};" > src/config/database.ts
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/src/events/guildCreate/index.ts
+++ b/src/events/guildCreate/index.ts
@@ -1,6 +1,6 @@
 import { Guild, WebhookClient } from 'discord.js';
 import { isEmpty } from 'lodash';
-import { GUILD_NOTIFICATION_WEBHOOK_URL, USE_DATABASE } from '../../config/environment';
+import { DATABASE_CONFIG, GUILD_NOTIFICATION_WEBHOOK_URL } from '../../config/environment';
 import { insertNewGuild } from '../../services/database';
 import { sendErrorLog, serverNotificationEmbed } from '../../utils/helpers';
 import { EventModule } from '../events';
@@ -8,7 +8,7 @@ import { EventModule } from '../events';
 export default function ({ app }: EventModule) {
   app.on('guildCreate', async (guild: Guild) => {
     try {
-      USE_DATABASE && (await insertNewGuild(guild));
+      DATABASE_CONFIG && (await insertNewGuild(guild));
       if (GUILD_NOTIFICATION_WEBHOOK_URL && !isEmpty(GUILD_NOTIFICATION_WEBHOOK_URL)) {
         const embed = await serverNotificationEmbed({ app, guild, type: 'join' });
         const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });

--- a/src/events/guildDelete/index.ts
+++ b/src/events/guildDelete/index.ts
@@ -1,6 +1,6 @@
 import { Guild, WebhookClient } from 'discord.js';
 import { isEmpty } from 'lodash';
-import { GUILD_NOTIFICATION_WEBHOOK_URL, USE_DATABASE } from '../../config/environment';
+import { DATABASE_CONFIG, GUILD_NOTIFICATION_WEBHOOK_URL } from '../../config/environment';
 import { deleteGuild } from '../../services/database';
 import { sendErrorLog, serverNotificationEmbed } from '../../utils/helpers';
 import { EventModule } from '../events';
@@ -8,7 +8,7 @@ import { EventModule } from '../events';
 export default function ({ app }: EventModule) {
   app.on('guildDelete', async (guild: Guild) => {
     try {
-      USE_DATABASE && (await deleteGuild(guild));
+      DATABASE_CONFIG && (await deleteGuild(guild));
       if (GUILD_NOTIFICATION_WEBHOOK_URL && !isEmpty(GUILD_NOTIFICATION_WEBHOOK_URL)) {
         const embed = await serverNotificationEmbed({ app, guild, type: 'leave' });
         const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -1,6 +1,6 @@
 import { REST, Routes } from 'discord.js';
 import { AppCommand } from '../../commands/commands';
-import { BOT_ID, BOT_TOKEN, ENV, GUILD_IDS, USE_DATABASE } from '../../config/environment';
+import { BOT_ID, BOT_TOKEN, DATABASE_CONFIG, ENV, GUILD_IDS } from '../../config/environment';
 import { createGuildTable, populateGuilds } from '../../services/database';
 import { sendBootNotification, sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
@@ -34,7 +34,7 @@ export default function ({ app, appCommands }: EventModule) {
   app.once('ready', async () => {
     try {
       await registerApplicationCommands(appCommands);
-      if (USE_DATABASE) {
+      if (DATABASE_CONFIG) {
         await createGuildTable();
         await populateGuilds(app.guilds.cache);
       }

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -1,6 +1,6 @@
 import { REST, Routes } from 'discord.js';
 import { AppCommand } from '../../commands/commands';
-import { BOT_ID, BOT_TOKEN, DATABASE_CONFIG, ENV, GUILD_IDS } from '../../config/environment';
+import { BOT_ID, BOT_TOKEN, DATABASE_CONFIG, ENV, GUILD_ID } from '../../config/environment';
 import { createGuildTable, populateGuilds } from '../../services/database';
 import { sendBootNotification, sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
@@ -13,9 +13,9 @@ const registerApplicationCommands = async (commands?: AppCommand[]) => {
 
   try {
     if (ENV === 'dev') {
-      if (GUILD_IDS) {
+      if (GUILD_ID) {
         //Registering guild-only commands to the bot i.e. only specified servers will see commands; I like to use a different bot when in development
-        await rest.put(Routes.applicationGuildCommands(BOT_ID, GUILD_IDS), {
+        await rest.put(Routes.applicationGuildCommands(BOT_ID, GUILD_ID), {
           body: commandList,
         });
         console.log('Successfully registered guild application commands');

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,8 +1,8 @@
 import { Collection, Guild } from 'discord.js';
 import { Pool, PoolClient } from 'pg';
-import { databaseConfig } from '../config/database';
+import { DATABASE_CONFIG } from '../config/environment';
 import { sendErrorLog } from '../utils/helpers';
-const pool: Pool = new Pool(databaseConfig);
+const pool = DATABASE_CONFIG ? new Pool(DATABASE_CONFIG) : null;
 
 type GuildRecord = {
   uuid: string;
@@ -12,6 +12,7 @@ type GuildRecord = {
 };
 
 export async function createGuildTable() {
+  if (!pool) return;
   const client: PoolClient = await pool.connect();
   if (client) {
     try {
@@ -29,6 +30,7 @@ export async function createGuildTable() {
   }
 }
 export async function getGuilds() {
+  if (!pool) return;
   const client: PoolClient = await pool.connect();
   if (client) {
     try {
@@ -60,6 +62,7 @@ export async function populateGuilds(existingGuilds: Collection<string, Guild>) 
   }
 }
 export async function insertNewGuild(newGuild: Guild) {
+  if (!pool) return;
   const client: PoolClient = await pool.connect();
   if (client) {
     try {
@@ -82,6 +85,7 @@ export async function insertNewGuild(newGuild: Guild) {
   }
 }
 export async function deleteGuild(existingGuild: Guild) {
+  if (!pool) return;
   const client: PoolClient = await pool.connect();
   if (client) {
     try {


### PR DESCRIPTION
#### Context
Was in the midst of writing this project's readme in #28 when I realised how flawed it was having the database configuration in a separate file. Figured this out since a user would have to create a `database.ts` file under `src/config` and export `databaseConfig` even if they don't even want to use a database. This isn't a required variable for the bot to actually run so it doesn't make sense forcing a user to go through this

Instead, I've moved this variable to the environment file instead which honestly should have been the proper solution from the start. Now we only really need `BOT_ID`, `BOT_TOKEN` and `GUILD_ID` to be set up for a project to get immediately started

#### Change
- Move database config to environment file
- Remove USE_DATABASE and use DATABASE_CONFIG instead
- Update tests workflow
