### PR TITLE
Refactor register command handler

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: mkdir src/config
       - name: Load environment config
         run: >
-          echo "export const ENV = 'dev'; export const BOT_TOKEN = ''; export const MIXPANEL_ID = ''; export const TOP_GG_TOKEN = '';
+          echo "export const ENV:string = 'dev'; export const BOT_TOKEN = ''; export const MIXPANEL_ID = ''; export const TOP_GG_TOKEN = '';
           export const GUILD_ID = ''; export const GUILD_NOTIFICATION_WEBHOOK_URL = ''; export const DATABASE_CONFIG = null; 
           export const ERROR_NOTIFICATION_WEBHOOK_URL = ''; export const BOOT_NOTIFICATION_CHANNEL_ID = ''; export const BOT_ID = '';" 
           > src/config/environment.ts

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -12,7 +12,11 @@ const registerApplicationCommands = async (commands?: AppCommand[]) => {
   const commandList = commands.map((command) => command.data.toJSON());
 
   try {
-    if (ENV === 'dev') {
+    if (ENV === 'prod') {
+      //Registering global commands for the bot i.e. every server bot is in will see commands; use this in production
+      await rest.put(Routes.applicationCommands(BOT_ID), { body: commandList });
+      console.log('Successfully registered global application commands');
+    } else {
       if (GUILD_ID) {
         //Registering guild-only commands to the bot i.e. only specified servers will see commands; I like to use a different bot when in development
         await rest.put(Routes.applicationGuildCommands(BOT_ID, GUILD_ID), {
@@ -20,10 +24,6 @@ const registerApplicationCommands = async (commands?: AppCommand[]) => {
         });
         console.log('Successfully registered guild application commands');
       }
-    } else {
-      //Registering global commands for the bot i.e. every server bot is in will see commands; use this in production
-      await rest.put(Routes.applicationCommands(BOT_ID), { body: commandList });
-      console.log('Successfully registered global application commands');
     }
   } catch (error) {
     sendErrorLog({ error });


### PR DESCRIPTION
#### Context
We're not making `ENV` as a required environment variable so having this current implementation would register commands globally. This pr flips it to check if ENV is `prod` instead and by default always register on a per-guild basis

#### Change
- Flip condition so env isn't required

