### PR TITLE
Support nested command folders

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -23,6 +23,8 @@ export function getApplicationCommands(): AppCommand[] {
     const files = fs.readdirSync(directoryPath, { withFileTypes: true });
     files.forEach((file) => {
       const filePath = path.join(directoryPath, file.name);
+      const nestingOccurence = filePath.match(new RegExp(/\//g) || [])?.length;
+      if (nestingOccurence && nestingOccurence >= 4) return; //We don't want to include any files/folders nested under the base command folder
       if (file.isDirectory()) {
         return loadModules(filePath);
       }


### PR DESCRIPTION
#### Context
Found an issue with the current implementation of loading command modules if there are nested folders within the base command. Saw this when working on nessie and the handler just keeps on going down through the folders until there's no more. With this change, we'll only take the base command and return early in the import loop if it's inside a nested folder

#### Change
- Add nested check when loading command modules
