### PR TITLE
Add wrong user interaction helper

### DIFF
--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -33,6 +33,7 @@ export default function ({ app, appCommands, mixpanel }: EventModule) {
           });
         }
       }
+      //Handle case where someone else tries to use an interaction not triggered by them
       if (interaction.isButton() || interaction.isAnySelectMenu()) {
         if (
           interaction.message.interaction &&

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,7 +1,7 @@
 import { ApplicationCommandOptionType, CacheType, Interaction } from 'discord.js';
 import { capitalize } from 'lodash';
 import { sendAnalyticsEvent } from '../../services/analytics';
-import { sendErrorLog } from '../../utils/helpers';
+import { sendErrorLog, sendWrongUserWarning } from '../../utils/helpers';
 import { EventModule } from '../events';
 
 export default function ({ app, appCommands, mixpanel }: EventModule) {
@@ -31,6 +31,15 @@ export default function ({ app, appCommands, mixpanel }: EventModule) {
             eventName,
             subCommand,
           });
+        }
+      }
+      if (interaction.isButton() || interaction.isAnySelectMenu()) {
+        if (
+          interaction.message.interaction &&
+          interaction.user.id !== interaction.message.interaction.user.id
+        ) {
+          sendWrongUserWarning({ interaction });
+          return;
         }
       }
       if (interaction.isButton()) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,7 @@
 import {
+  AnySelectMenuInteraction,
   APIEmbed,
+  ButtonInteraction,
   Channel,
   Client,
   CommandInteraction,
@@ -143,4 +145,19 @@ export const sendBootNotification = async (app: Client) => {
 //Returns a default color if no argument is passed
 export const getEmbedColor = (color?: string): number => {
   return parseInt(color ? color.replace('#', '0x') : '#3399FF'.replace('#', '0x'));
+};
+
+export const sendWrongUserWarning = async ({
+  interaction,
+}: {
+  interaction: ButtonInteraction | AnySelectMenuInteraction;
+}) => {
+  const wrongUserEmbed = {
+    description: `Oops looks like that interaction wasn't meant for you! I can only properly interact with your own commands.\n\nTo check what I can do, type ${inlineCode(
+      '/help'
+    )}!`,
+    color: getEmbedColor('#FF0000'),
+  };
+  await interaction.deferReply({ ephemeral: true });
+  interaction.editReply({ embeds: [wrongUserEmbed] });
 };


### PR DESCRIPTION
#### Context
Pretty irrelevant atm since there's no buttons or select menus being used but adding it regardless for the future. This basically show an ephemeral message to the user who triggers an interaction not associated to them

#### Change
- Add wrong user helper
- Wire up hander in interaction listener