### PR TITLE
Use edit reply instead of reply after defer

### DIFF
--- a/src/commands/about/index.ts
+++ b/src/commands/about/index.ts
@@ -58,7 +58,7 @@ export default {
     try {
       await interaction.deferReply();
       const embed = generateAboutEmbed(app);
-      await interaction.reply({ embeds: [embed] });
+      await interaction.editReply({ embeds: [embed] });
     } catch (error) {
       sendErrorLog({ error, interaction });
     }

--- a/src/commands/help/index.ts
+++ b/src/commands/help/index.ts
@@ -41,7 +41,7 @@ export default {
     try {
       await interaction.deferReply();
       const embed = generateHelpEmbed(appCommands);
-      await interaction.reply({ embeds: [embed] });
+      await interaction.editReply({ embeds: [embed] });
     } catch (error) {
       sendErrorLog({ error, interaction });
     }

--- a/src/commands/invite/index.ts
+++ b/src/commands/invite/index.ts
@@ -19,7 +19,7 @@ export default {
     try {
       await interaction.deferReply();
       const embed = generateInviteEmbed();
-      await interaction.reply({ embeds: [embed] });
+      await interaction.editReply({ embeds: [embed] });
     } catch (error) {
       sendErrorLog({ error, interaction });
     }


### PR DESCRIPTION
#### Context
I added defer reply in #39 but didn't update .reply on the commands. This makes it so the command actually errors as we've told djs the interaction has been acknowledged already. Instead of reply, the correct usage here is .editReply

#### Change
- Use editReply instead of reply after defer
